### PR TITLE
Allow download_data to run for 120 minutes

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -2,7 +2,7 @@ name: Download data required by ScopeSim
 
 on:
   schedule:
-    - # Run every day at 5:00 UTC
+    # Run every day at 5:00 UTC
     - cron: "0 5 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
@@ -11,6 +11,7 @@ on:
 jobs:
   download_data:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION
It seems the CI is cancelling the job after 75 minutes or so