### PR TITLE
Install IRDB from CI requirements

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -37,6 +37,7 @@ jobs:
 
       # Create a PR with the changes from the above script, if any.
       - name: Create Pull Request
+        if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "Update stored data"

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -53,7 +53,7 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.download_data.result == 'failure' || needs.download_data.result == 'timed_out') && !(github.event_name == 'pull_request') }}
+    if: ${{ always() && (needs.download_data.result == 'failure' || needs.download_data.result == 'timed_out') && (github.event_name != 'pull_request') }}
     needs:
       - download_data
     steps:

--- a/bin/download_scopesim_data.sh
+++ b/bin/download_scopesim_data.sh
@@ -100,10 +100,10 @@ poetry update --with=test,dev,docs
 popd
 
 git clone https://github.com/AstarVienna/irdb.git
-# pushd irdb
+pushd irdb
 # irdb doesn't use poetry yet
-# pip install -e ".[test]"
-# popd
+pip install -r requirements.github_actions.txt
+popd
 
 # poetry update will upgrade only to the latest versions that are released.
 # The packages will therefore downgrade each other.

--- a/bin/download_scopesim_data.sh
+++ b/bin/download_scopesim_data.sh
@@ -100,10 +100,10 @@ poetry update --with=test,dev,docs
 popd
 
 git clone https://github.com/AstarVienna/irdb.git
-pushd irdb
+# pushd irdb
 # irdb doesn't use poetry yet
-pip install -e ".[test]"
-popd
+# pip install -e ".[test]"
+# popd
 
 # poetry update will upgrade only to the latest versions that are released.
 # The packages will therefore downgrade each other.
@@ -119,7 +119,7 @@ pip install -e ScopeSim
 pip install -e ScopeSim_Templates
 pip install -e skycalc_ipy
 pip install -e AnisoCADO
-pip install -e irdb
+# pip install -e irdb
 
 
 # Run the tests.


### PR DESCRIPTION
IRDB doesn't use poetry (yet), but rather a setup.py file. I recently removed the version.py file there, causing the installation to fail. The obvious solution would be to fix this in the IRDB, and I will do that. But than it occurred to me, why do we even need to install the IRDB here? What does it even mean to "install the IRDB"?? Well, I'm assuming this is to make sure all the test dependencies are here to run the tests. But all of those are already installed anyway from all the other packages.

Well, that didn't work, because the "internal" IRDB tests have at least one unique dependency. However, installing from [`requirements.github_actions.txt`](https://github.com/AstarVienna/irdb/blob/dev_master/requirements.github_actions.txt) for the case of the IRDB seems to work, which is how the tests are run in the CI over there anyway...