### PR TITLE
Run main script only twice a week

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -11,8 +11,8 @@ on:
       - ready_for_review
 
   schedule:
-    # Run every day at 6:00 UTC
-    - cron: "0 6 * * *"
+    # Runs at 05:30 UTC, only on Monday and Wednesday
+    - cron: "30 5 * * MON,WED"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
I think it's fine for the purpose of what this is meant to do. If we need it at any other day for a specific reason, we can always run it manually anyway. Feel free to disagree 🙂

The 5:30 is because [the docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule) recommend not running on the full hour if not necessary to spread the load on the servers more evenly.