### PR TITLE
Rework dependency resolution, use Poetry and pip

### DIFF
--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -24,16 +24,27 @@ jobs:
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v7
+
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry==2.4.1
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: 3.13
+
       - name: Install dependencies
         run: |
+          python -m venv envdata
+          source envdata/bin/activate
           python -m pip install --upgrade pip
           pip install -e .
+          poetry install
+
       - name: Run download script
-        run: bash bin/download_scopesim_data.sh
+        # run: poetry run main_script  # doesn't work, with nonsensical message -.-
+        run: poetry run bash bin/download_scopesim_data.sh
 
       # Create a PR with the changes from the above script, if any.
       - name: Create Pull Request

--- a/.github/workflows/download_data.yml
+++ b/.github/workflows/download_data.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/bin/download_scopesim_data.sh
+++ b/bin/download_scopesim_data.sh
@@ -67,25 +67,19 @@ git clone https://github.com/AstarVienna/AnisoCADO.git
 git clone https://github.com/AstarVienna/ScopeSim_Templates.git
 git clone https://github.com/AstarVienna/irdb.git
 
-# poetry update will upgrade only to the latest versions that are released.
-# The packages will therefore downgrade each other.
-# But ScopeSim_Data should use the latest version of all our projects
-# (to download the data they need, and to test whether they work together).
-# So the projects need to be installed again.
-# Note that it is not possible to only use pip, poetry is required to install
-# the dependency groups (that is, dev/test/docs). See
-# https://stackoverflow.com/questions/76118614/is-it-possible-to-install-poetry-groups-with-pip
-pip install -e Pyckles
-pip install -e speXtra
-pip install -e ScopeSim
-pip install -e ScopeSim_Templates
-pip install -e skycalc_ipy
-pip install -e AnisoCADO
-
+# These need to be in descending order to avoid overwriting
+# a dev install with a released version.
 pushd irdb
 # irdb doesn't use poetry yet
 pip install -r requirements.github_actions.txt
 popd
+
+pip install -e ScopeSim_Templates
+pip install -e ScopeSim
+pip install -e speXtra
+pip install -e skycalc_ipy
+pip install -e Pyckles
+pip install -e AnisoCADO
 
 
 # Run the tests.

--- a/bin/download_scopesim_data.sh
+++ b/bin/download_scopesim_data.sh
@@ -26,8 +26,6 @@ function cleanup {
 trap cleanup EXIT
 
 
-
-
 if [[ $# -gt 1 ]]; then
   echo "Usage: $0 [data directory]"
   exit 2
@@ -61,49 +59,13 @@ pipx install poetry==2.4.1
 # All poetry files are updated with `poetry update` to ensure we test the latest
 # versions of our dependencies.
 
-# Pyckles must go first, because otherwise it uninstalls scipy (????). See
-# https://stackoverflow.com/questions/67085976/how-to-stop-poetry-from-uninstalling-packages
 git clone https://github.com/AstarVienna/Pyckles.git
-pushd Pyckles
-poetry install --with=test,docs
-poetry update --with=test,docs
-popd
-
 git clone https://github.com/AstarVienna/speXtra.git
-pushd speXtra
-poetry install --with=test,docs
-poetry update --with=test,docs
-popd
-
 git clone https://github.com/AstarVienna/ScopeSim.git
-pushd ScopeSim
-poetry install --with=test,dev,docs
-poetry update --with=test,dev,docs
-popd
-
 git clone https://github.com/AstarVienna/skycalc_ipy.git
-pushd skycalc_ipy
-poetry install --with=test,docs
-poetry update --with=test,docs
-popd
-
 git clone https://github.com/AstarVienna/AnisoCADO.git
-pushd AnisoCADO
-poetry install --with=test,docs
-poetry update --with=test,docs
-popd
-
 git clone https://github.com/AstarVienna/ScopeSim_Templates.git
-pushd ScopeSim_Templates
-poetry install --with=test,dev,docs
-poetry update --with=test,dev,docs
-popd
-
 git clone https://github.com/AstarVienna/irdb.git
-pushd irdb
-# irdb doesn't use poetry yet
-pip install -r requirements.github_actions.txt
-popd
 
 # poetry update will upgrade only to the latest versions that are released.
 # The packages will therefore downgrade each other.
@@ -119,7 +81,11 @@ pip install -e ScopeSim
 pip install -e ScopeSim_Templates
 pip install -e skycalc_ipy
 pip install -e AnisoCADO
-# pip install -e irdb
+
+pushd irdb
+# irdb doesn't use poetry yet
+pip install -r requirements.github_actions.txt
+popd
 
 
 # Run the tests.

--- a/bin/download_scopesim_data.sh
+++ b/bin/download_scopesim_data.sh
@@ -49,10 +49,10 @@ mkdir -p "${DIR_DATA}"
 export SCOPESIM_DATA_CI_FLAG=1
 
 # Create the environment.
-pushd "${DIR_WORK}"
 python -m venv envdata
 source envdata/bin/activate
-pipx install poetry==2.4.1
+pip install -e .
+pushd "${DIR_WORK}"
 
 # Download and install all the packages. Has to be done from git, because the
 # releases do not (always) have the test files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,42 @@
 [project]
 name = "ScopeSim_Data"
-version = "0.0.1-alpha"
+version = "0.1.0.dev0"
 description = "Data often used by ScopeSim and related tools."
 readme = "README.md"
-requires-python = ">=3.8"
-license = {text = "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"}
+requires-python = ">=3.12, <3.15"
+license = "GPL-3.0-or-later"
 authors = [
-    {name = "Hugo Buddelmeijer", email="hugo@buddelmeijer.nl"},
+    {name = "Hugo Buddelmeijer", email = "hugo@buddelmeijer.nl"},
 ]
 maintainers = [
-    {name = "Kieran Leschinski", email="kieran.leschinski@unive.ac.at"},
-    {name = "Hugo Buddelmeijer", email="hugo@buddelmeijer.nl"},
+    {name = "Kieran Leschinski", email = "kieran.leschinski@univie.ac.at"},
+    {name = "Hugo Buddelmeijer", email = "hugo@buddelmeijer.nl"},
+    {name = "Fabian Haberhauer", email = "fabian.haberhauer@univie.ac.at"},
 ]
-classifiers=[
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Astronomy",
-]
+dynamic = [ "classifiers" ]
 dependencies = []
 
 [project.urls]
 "Source" = "https://github.com/AstarVienna/ScopeSim_Data"
 
-# TODO: Figure out whether the below actually puts the script in the PATH somewhere.
-[tools.setuptools]
-script_files = "bin/download_scopesim_data.sh"
+[tool.poetry]
+package-mode = true  # Needs to pretend to be a package to be imported
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Astronomy",
+]
 
-[tool.setuptools.packages]
-find = {}
+[tool.poetry.group.test.dependencies]
+pytest = "^9.1.1"
+pytest-notebook = ">=0.11.0"
+myst-nb = "^1.4.0"
+
+[tool.poetry.scripts]
+main_script = { reference = "bin/download_scopesim_data.sh", type = "file" }
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+


### PR DESCRIPTION
TLDR: Use Poetry for the toml file, use pip for the workflow script.

The reason we previously used the Poetry installs of all of them was that the optional dependencies in the test group can only be installed that way. But this created the problem of versions overwriting each other. It turns out, most of these packages only have pytest (and pytest-cov) in the test dependency group anyway. So if we install all the packages just using pip (still from the latest commit on main) and inject pytest etc. into the same environment, we can still run all the tests. The order of installation is still relevant, because even pip will uninstall dependencies it thinks are incompatible. This also affects some of the internal ones, e.g. if one main is already on a dev version from a release that would be out-of-range of something that depends on it, that would be reinstalled with a released version. By installing them "from the top down", we can prevent that. pip complains that it's "incompatible", but still installs it.

In any case, it works now and was failing before...